### PR TITLE
Add Helper to recognize ObjectId in /aggregrator

### DIFF
--- a/lib/ObjectIdHelper.js
+++ b/lib/ObjectIdHelper.js
@@ -1,0 +1,124 @@
+var mongoose = require('mongoose')
+
+var Types = mongoose.Types
+
+function isCouldbeObjectId(str) {
+  if (typeof str === 'string') {
+      return /^[a-f\d]{24}$/i.test(str);
+  } else if (Array.isArray(str)) {
+      return str.every(arrStr => /^[a-f\d]{24}$/i.test(arrStr));
+  }
+  return false;
+}
+
+/**
+ * Converts a query of ObjectId's to $or with the string value
+ * and the casted ObjectId values
+ *
+ *    {
+ *        user: objIdStr,
+ *        user1: {
+ *            $in: [objIdStr, objIdStr],
+ *        },
+ *        subobject: {
+ *            user: objIdStr,
+ *            user1: {
+ *                $in: [objIdStr, objIdStr],
+ *            },
+ *        },
+ *    }
+ *
+ * Will be converted to:
+ *
+ *    {
+ *        $and: [
+ *            { $or: [{ user: objIdStr }, { user: objIdObj }] },
+ *            {
+ *                $or: [
+ *                    { user1: { $in: [objIdStr, objIdStr] } },
+ *                    { user1: { $in: [objIdObj, objIdObj] } },
+ *                ],
+ *            },
+ *        ],
+ *        subobject: {
+ *             $and: [
+ *                { $or: [{ user: objIdStr }, { user: objIdObj }] },
+ *                {
+ *                    $or: [
+ *                        { user1: { $in: [objIdStr, objIdStr] } },
+ *                        { user1: { $in: [objIdObj, objIdObj] } }
+ *                    ],
+ *                },
+ *            ],
+ *        },
+ *    },
+ *
+ * @param {Object} query the query that will be converted
+ * @return converted query
+ */
+function convertToObjectId$or(query) {
+  /* eslint-disable no-param-reassign */
+  if (typeof query !== 'object' || Array.isArray(query)) {
+      return query;
+  }
+
+  return Object.keys(query).reduce((curr, subKey) => {
+      if (isCouldbeObjectId(query[subKey])) {
+          // Is an array of strings similar to ObjectId
+          // or an string similar to ObjectId
+          let multiMatch;
+          const $or = [];
+
+          multiMatch = {};
+          multiMatch[subKey] = query[subKey];
+          $or.push(multiMatch);
+
+          multiMatch = {};
+          multiMatch[subKey] = Array.isArray(query[subKey]) ?
+              query[subKey].map(v => new Types.ObjectId(v)) :
+              new Types.ObjectId(query[subKey]);
+          $or.push(multiMatch);
+
+          if (curr.$and) {
+              curr.$and.push({ $or });
+          } else if (curr.$or) {
+              curr.$and = [{ $or: curr.$or }, { $or }];
+              delete curr.$or;
+          } else {
+              curr.$or = $or;
+          }
+      } else if (typeof query[subKey] === 'object' && query[subKey].$in && isCouldbeObjectId(query[subKey].$in)) {
+          // Is an array of strings similar to ObjectId
+          // or an string similar to ObjectId
+          let multiMatch;
+          const $or = [];
+
+          multiMatch = {};
+          multiMatch[subKey] = query[subKey];
+          $or.push(multiMatch);
+
+          multiMatch = {};
+          multiMatch[subKey] = {
+              $in: query[subKey].$in.map(v => new Types.ObjectId(v)),
+          };
+          $or.push(multiMatch);
+
+          if (curr.$and) {
+              curr.$and.push({ $or });
+          } else if (curr.$or) {
+              curr.$and = [{ $or: curr.$or }, { $or }];
+              delete curr.$or;
+          } else {
+              curr.$or = $or;
+          }
+      } else if (typeof query[subKey] === 'object' && !Array.isArray(query[subKey])) {
+          curr[subKey] = convertToObjectId$or(query[subKey]);
+      } else {
+          curr[subKey] = query[subKey];
+      }
+      return curr;
+  }, {});
+  /* eslint-enable no-param-reassign */
+}
+
+module.exports = convertToObjectId$or

--- a/lib/RouterFactory.js
+++ b/lib/RouterFactory.js
@@ -1,6 +1,8 @@
 var express = require('express')
 var mongoose = require('mongoose')
 
+var ObjectIdHelper = require('./ObjectIdHelper')
+
 function Router(model) {
   var router = express.Router()
   var Model = model
@@ -67,7 +69,12 @@ function Router(model) {
 
     var conditions = req.body || []
 
-    Model.aggregate(conditions).exec()
+    var normalizedConditions = []
+
+    // Normalized Query, check ObjectIdHelper.js for more info
+    Object.keys(conditions).map(pipeIndex => normalizedConditions[pipeIndex] = ObjectIdHelper(conditions[pipeIndex]))
+
+    Model.aggregate(normalizedConditions).exec()
       .then(function(result) { return res.send({ status: (result.length > 0) ? 200 : 404, payload: result, msg: (result.length > 0) ? 'Return all aggregated payload that match filter' : 'No docs found', query: conditions }) })
       .catch(function(err) { return res.send({ status: 400, msg: err }) })
   })

--- a/lib/RouterFactory.js
+++ b/lib/RouterFactory.js
@@ -79,7 +79,7 @@ function Router(model) {
     conditions.map(obj => normalizedConditions.push(ObjectIdHelper(obj)))
 
     Model.aggregate(normalizedConditions).exec()
-      .then(function(result) { return res.send({ status: (result.length > 0) ? 200 : 404, payload: result, msg: (result.length > 0) ? 'Return all aggregated payload that match filter' : 'No docs found', query: normalizedConditions }) })
+      .then(function(result) { return res.send({ status: (result.length > 0) ? 200 : 404, payload: result, msg: (result.length > 0) ? 'Return all aggregated payload that match filter' : 'No docs found', query: conditions }) })
       .catch(function(err) { return res.send({ status: 400, msg: err }) })
   })
 

--- a/lib/RouterFactory.js
+++ b/lib/RouterFactory.js
@@ -69,13 +69,17 @@ function Router(model) {
 
     var conditions = req.body || []
 
+    if (!(conditions instanceof Array)) {
+      return res.send({ status: 400, msg: 'Bad Request, request must be an array'})
+    }
+
     var normalizedConditions = []
 
     // Normalized Query, check ObjectIdHelper.js for more info
-    Object.keys(conditions).map(pipeIndex => normalizedConditions[pipeIndex] = ObjectIdHelper(conditions[pipeIndex]))
+    conditions.map(obj => normalizedConditions.push(ObjectIdHelper(obj)))
 
     Model.aggregate(normalizedConditions).exec()
-      .then(function(result) { return res.send({ status: (result.length > 0) ? 200 : 404, payload: result, msg: (result.length > 0) ? 'Return all aggregated payload that match filter' : 'No docs found', query: conditions }) })
+      .then(function(result) { return res.send({ status: (result.length > 0) ? 200 : 404, payload: result, msg: (result.length > 0) ? 'Return all aggregated payload that match filter' : 'No docs found', query: normalizedConditions }) })
       .catch(function(err) { return res.send({ status: 400, msg: err }) })
   })
 


### PR DESCRIPTION
The current version of the library (`0.2.1`) cannot query by ObjectId in `/aggregrate` because we pass the ObjectId as a string in JSON request.

My solution is adding `ObjectIdHelper.js` to help recognize ObjectId in `/aggregator` query.

The helper will detect and convert any valid ObjectId to its `$or` representation

Example case:
```
[
	{
		"$match": {
			"_id": "5afbe0bd94c9136d2a16f474"
		}
	}
]
```
will converted to

```
[
    {
        "$match": {
            "$or": [
                {
                    "_id": "5afbe0bd94c9136d2a16f474"
                },
                {
                    "_id": ObjectId("5afbe0bd94c9136d2a16f474")
                }
            ]
        }
    }
]
```
